### PR TITLE
fix: start ratelimiter slowly, don't burst

### DIFF
--- a/client.go
+++ b/client.go
@@ -292,6 +292,7 @@ func (client *Client) Login() error {
 	for attempts := 0; ; attempts++ {
 		req := client.NewReq("POST", "/api/fmc_platform/v1/auth/generatetoken", strings.NewReader(""), NoLogPayload)
 		req.HttpReq.SetBasicAuth(client.Usr, client.Pwd)
+		client.RateLimiterBucket.Wait(1)
 		httpRes, err := client.HttpClient.Do(req.HttpReq)
 		if err != nil {
 			return err
@@ -338,6 +339,7 @@ func (client *Client) Refresh() error {
 		req := client.NewReq("POST", "/api/fmc_platform/v1/auth/refreshtoken", strings.NewReader(""), NoLogPayload)
 		req.HttpReq.Header.Add("X-auth-access-token", client.AuthToken)
 		req.HttpReq.Header.Add("X-auth-refresh-token", client.RefreshToken)
+		client.RateLimiterBucket.Wait(1)
 		httpRes, err := client.HttpClient.Do(req.HttpReq)
 		if err != nil {
 			return err

--- a/client.go
+++ b/client.go
@@ -296,12 +296,12 @@ func (client *Client) Login() error {
 		if err != nil {
 			return err
 		}
+		defer httpRes.Body.Close()
+		bodyBytes, _ := io.ReadAll(httpRes.Body)
 		if httpRes.StatusCode != 204 {
 			log.Printf("[ERROR] Authentication failed: StatusCode %v", httpRes.StatusCode)
 			return fmt.Errorf("authentication failed, status code: %v", httpRes.StatusCode)
 		}
-		defer httpRes.Body.Close()
-		bodyBytes, _ := io.ReadAll(httpRes.Body)
 		if len(bodyBytes) > 0 {
 			if ok := client.Backoff(attempts); !ok {
 				log.Printf("[ERROR] Authentication failed: Invalid credentials")
@@ -342,12 +342,12 @@ func (client *Client) Refresh() error {
 		if err != nil {
 			return err
 		}
+		defer httpRes.Body.Close()
+		bodyBytes, _ := io.ReadAll(httpRes.Body)
 		if httpRes.StatusCode != 204 {
 			log.Printf("[ERROR] Authentication failed: StatusCode %v", httpRes.StatusCode)
 			return fmt.Errorf("authentication failed, status code: %v", httpRes.StatusCode)
 		}
-		defer httpRes.Body.Close()
-		bodyBytes, _ := io.ReadAll(httpRes.Body)
 		if len(bodyBytes) > 0 {
 			if ok := client.Backoff(attempts); !ok {
 				log.Printf("[ERROR] Authentication failed: Invalid credentials")


### PR DESCRIPTION
### Problem

The usual flow is that refresh stage runs lots and lots of requests, saturating the rate limiter.

Then in the execution stage, a *new* client is constructed. Having a fresh rate limiter, it may immediately produce a burst of 100 requests. API would start failing them.

Also, the login and refresh requests aren't protected by rate limiter at all, and they seem to fail in practice (with 401, instead of 429 somehow?).

### Solution

Solution: start with just 1 request.

The long-term rate is not changed, because the two are
approximately equal:

- previous 100 req per minute
- current 1.66 req per second

Apply the rate limit to the auth HTTP POST as well.

Log after Wait(1), instead of before, in order to have more precise
timestamps in logs.

### Logs

What was failing before the change:

```terraform
resource "fmc_host" "test" {
	count = 51
	name = "host${count.index}"
	ip = "10.1.1.${count.index}"
}
```

I used `-parallelism=1` just to avoid concurrency. I only wanted sequential request rate.

After apply and refresh, the first 4 logins returned 401 and executed
without any delays, further logins all succeeded. Test was repeatable:

```
2024-05-22T13:35:50.232+0200 [DEBUG] provider.terraform-provider-fmc: plugin address: address=/tmp/plugin2106920803 network=unix timestamp="2024-05-22T13:35:50.232+0200"
2024-05-22T13:35:50.242+0200 [INFO]  Starting apply for fmc_host.test[1]
2024-05-22T13:35:50.242+0200 [DEBUG] fmc_host.test[1]: applying the planned Delete change
2024-05-22T13:35:50.244+0200 [DEBUG] provider.terraform-provider-fmc: 0050568A-3746-0ed3-0000-017179876690: Beginning Delete: tf_req_id=99e8b2f0-4e4e-6545-147f-e9845b1695fa tf_resource_type=fmc_host tf_rpc=ApplyResourceChange @caller=/home/kubit/go/src/github.com/netascode/terraform-provider-fmc/internal/provider/resource_fmc_host.go:246 @module=fmc tf_provider_addr=registry.terraform.io/netascode/fmc timestamp="2024-05-22T13:35:50.244+0200"
2024-05-22T13:35:50.741+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:50 [ERROR] Authentication failed: StatusCode 401
2024-05-22T13:35:50.741+0200 [ERROR] provider.terraform-provider-fmc: Response contains error diagnostic: diagnostic_summary="Client Error" tf_resource_type=fmc_host @module=sdk.proto diagnostic_severity=ERROR tf_proto_version=6.6 tf_req_id=99e8b2f0-4e4e-6545-147f-e9845b1695fa @caller=/home/kubit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/diag/diagnostics.go:58 diagnostic_detail="Failed to delete object (DELETE), got error: authentication failed, status code: 401, " tf_rpc=ApplyResourceChange tf_provider_addr=registry.terraform.io/netascode/fmc timestamp="2024-05-22T13:35:50.741+0200"
2024-05-22T13:35:50.757+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
2024-05-22T13:35:50.757+0200 [ERROR] vertex "fmc_host.test[1] (destroy)" error: Client Error
2024-05-22T13:35:50.758+0200 [INFO]  Starting apply for fmc_host.test[15]
2024-05-22T13:35:50.758+0200 [DEBUG] fmc_host.test[15]: applying the planned Delete change
2024-05-22T13:35:50.759+0200 [DEBUG] provider.terraform-provider-fmc: 0050568A-3746-0ed3-0000-017179876870: Beginning Delete: tf_provider_addr=registry.terraform.io/netascode/fmc tf_req_id=a93f7da9-711d-9a4e-8217-4ce25eee861c tf_resource_type=fmc_host tf_rpc=ApplyResourceChange @caller=/home/kubit/go/src/github.com/netascode/terraform-provider-fmc/internal/provider/resource_fmc_host.go:246 @module=fmc timestamp="2024-05-22T13:35:50.759+0200"
2024-05-22T13:35:51.167+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:51 [ERROR] Authentication failed: StatusCode 401
2024-05-22T13:35:51.167+0200 [ERROR] provider.terraform-provider-fmc: Response contains error diagnostic: tf_proto_version=6.6 tf_resource_type=fmc_host @module=sdk.proto diagnostic_summary="Client Error" tf_req_id=a93f7da9-711d-9a4e-8217-4ce25eee861c tf_rpc=ApplyResourceChange @caller=/home/kubit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/diag/diagnostics.go:58 diagnostic_detail="Failed to delete object (DELETE), got error: authentication failed, status code: 401, " diagnostic_severity=ERROR tf_provider_addr=registry.terraform.io/netascode/fmc timestamp="2024-05-22T13:35:51.167+0200"
2024-05-22T13:35:51.183+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
2024-05-22T13:35:51.183+0200 [ERROR] vertex "fmc_host.test[15] (destroy)" error: Client Error
2024-05-22T13:35:51.184+0200 [INFO]  Starting apply for fmc_host.test[7]
2024-05-22T13:35:51.184+0200 [DEBUG] fmc_host.test[7]: applying the planned Delete change
2024-05-22T13:35:51.185+0200 [DEBUG] provider.terraform-provider-fmc: 0050568A-3746-0ed3-0000-017179876636: Beginning Delete: @caller=/home/kubit/go/src/github.com/netascode/terraform-provider-fmc/internal/provider/resource_fmc_host.go:246 @module=fmc tf_provider_addr=registry.terraform.io/netascode/fmc tf_req_id=5fd5a966-3b37-2940-ee71-9a9ff18742bb tf_resource_type=fmc_host tf_rpc=ApplyResourceChange timestamp="2024-05-22T13:35:51.185+0200"
2024-05-22T13:35:51.586+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:51 [ERROR] Authentication failed: StatusCode 401
2024-05-22T13:35:51.587+0200 [ERROR] provider.terraform-provider-fmc: Response contains error diagnostic: diagnostic_summary="Client Error" tf_proto_version=6.6 tf_req_id=5fd5a966-3b37-2940-ee71-9a9ff18742bb @caller=/home/kubit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/diag/diagnostics.go:58 tf_rpc=ApplyResourceChange diagnostic_severity=ERROR tf_provider_addr=registry.terraform.io/netascode/fmc tf_resource_type=fmc_host @module=sdk.proto diagnostic_detail="Failed to delete object (DELETE), got error: authentication failed, status code: 401, " timestamp="2024-05-22T13:35:51.586+0200"
2024-05-22T13:35:51.594+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
2024-05-22T13:35:51.594+0200 [ERROR] vertex "fmc_host.test[7] (destroy)" error: Client Error
2024-05-22T13:35:51.596+0200 [INFO]  Starting apply for fmc_host.test[49]
2024-05-22T13:35:51.596+0200 [DEBUG] fmc_host.test[49]: applying the planned Delete change
2024-05-22T13:35:51.596+0200 [DEBUG] provider.terraform-provider-fmc: 0050568A-3746-0ed3-0000-017179876600: Beginning Delete: @module=fmc tf_resource_type=fmc_host @caller=/home/kubit/go/src/github.com/netascode/terraform-provider-fmc/internal/provider/resource_fmc_host.go:246 tf_provider_addr=registry.terraform.io/netascode/fmc tf_req_id=d01ae645-38ee-07bb-5bb0-59fdf8fb4d25 tf_rpc=ApplyResourceChange timestamp="2024-05-22T13:35:51.596+0200"
2024-05-22T13:35:51.767+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:51 [ERROR] Authentication failed: StatusCode 401
2024-05-22T13:35:51.767+0200 [ERROR] provider.terraform-provider-fmc: Response contains error diagnostic: @caller=/home/kubit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/diag/diagnostics.go:58 tf_proto_version=6.6 tf_req_id=d01ae645-38ee-07bb-5bb0-59fdf8fb4d25 tf_resource_type=fmc_host diagnostic_detail="Failed to delete object (DELETE), got error: authentication failed, status code: 401, " diagnostic_severity=ERROR tf_rpc=ApplyResourceChange @module=sdk.proto diagnostic_summary="Client Error" tf_provider_addr=registry.terraform.io/netascode/fmc timestamp="2024-05-22T13:35:51.767+0200"
2024-05-22T13:35:51.775+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
2024-05-22T13:35:51.775+0200 [ERROR] vertex "fmc_host.test[49] (destroy)" error: Client Error
2024-05-22T13:35:51.776+0200 [INFO]  Starting apply for fmc_host.test[26]
2024-05-22T13:35:51.776+0200 [DEBUG] fmc_host.test[26]: applying the planned Delete change
2024-05-22T13:35:51.777+0200 [DEBUG] provider.terraform-provider-fmc: 0050568A-3746-0ed3-0000-017179876222: Beginning Delete: @caller=/home/kubit/go/src/github.com/netascode/terraform-provider-fmc/internal/provider/resource_fmc_host.go:246 tf_provider_addr=registry.terraform.io/netascode/fmc tf_rpc=ApplyResourceChange @module=fmc tf_req_id=d07b8ea4-b499-9974-7d18-17cc2086f753 tf_resource_type=fmc_host timestamp="2024-05-22T13:35:51.777+0200"
2024-05-22T13:35:53.568+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:53 [DEBUG] Found domain: Global, UUID: e276abec-e0f2-11e3-8169-6d9ed49b625f
2024-05-22T13:35:53.568+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:53 [DEBUG] Authentication successful
2024-05-22T13:35:53.568+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:53 [DEBUG] HTTP Request: DELETE, https://10.50.202.44/api/fmc_config/v1/domain/e276abec-e0f2-11e3-8169-6d9ed49b625f/object/hosts/0050568A-3746-0ed3-0000-017179876222, {}
2024-05-22T13:35:54.188+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:54 [DEBUG] HTTP Response: {"links":{"self":"[https://10.50.202.44/api/fmc_config/v1/domain/e276abec-e0f2-11e3-8169-6d9ed49b625f/object/hosts/0050568A-3746-0ed3-0000-017179876222","parent":"https://10.50.202.44/api/fmc_config/v1/domain/e276abec-e0f2-11e3-8169-6d9ed49b625f/object/networkaddresses"},"type":"Host","value":"10.1.1.26","overridable":false,"description](https://10.50.202.44/api/fmc_config/v1/domain/e276abec-e0f2-11e3-8169-6d9ed49b625f/object/hosts/0050568A-3746-0ed3-0000-017179876222%22,%22parent%22:%22https://10.50.202.44/api/fmc_config/v1/domain/e276abec-e0f2-11e3-8169-6d9ed49b625f/object/networkaddresses%22%7D,%22type%22:%22Host%22,%22value%22:%2210.1.1.26%22,%22overridable%22:false,%22description)":" ","name":"ho26","id":"0050568A-3746-0ed3-0000-017179876222","metadata":{"timestamp":1716376224250,"lastUser":{"name":"admin"},"domain":{"name":"Global","id":"e276abec-e0f2-11e3-8169-6d9ed49b625f","type":"Domain"},"ipType":"V_4","parentType":"NetworkAddress"}}
2024-05-22T13:35:54.188+0200 [DEBUG] provider.terraform-provider-fmc: 2024/05/22 13:35:54 [DEBUG] Exit from Do method
```