### PR TITLE
Check if provided domain is valid

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -75,10 +75,14 @@ func TestClientGet(t *testing.T) {
 	_, err = client.Get("/url/{DOMAIN_UUID}/")
 	assert.NoError(t, err)
 
-	// URL global domain uuid
+	// URL select existing domain
 	gock.New(testURL).Get("/url/DEF456/").Reply(200)
 	_, err = client.Get("/url/{DOMAIN_UUID}/", DomainName("dom1"))
 	assert.NoError(t, err)
+
+	// URL select non-existing domain
+	_, err = client.Get("/url/{DOMAIN_UUID}/", DomainName("dom_does_not_exist"))
+	assert.Error(t, err)
 
 	// HTTP error
 	gock.New(testURL).Get("/url").ReplyError(errors.New("fail"))


### PR DESCRIPTION
Currently, when wrong domain is provided, the following error is returned
```
HTTP Request failed: StatusCode 404,
│ {"error":{"category":"FRAMEWORK","messages":[{"description":"Invalid Request"}],"severity":"ERROR"}}
```

This change is to make it more as:
```
Requested domain not found: requested domain: Global/Sub1Domain, available domains: [Global Global/Sub1 Global/Sub2]
```