### PR TITLE
Handling of unexpectedly terminated sessions

### DIFF
--- a/client.go
+++ b/client.go
@@ -229,14 +229,20 @@ func (client *Client) Do(req Req) (Res, error) {
 			} else if httpRes.StatusCode == 429 || (httpRes.StatusCode >= 500 && httpRes.StatusCode <= 599) {
 				log.Printf("[ERROR] HTTP Request failed: StatusCode %v, Retries: %v", httpRes.StatusCode, attempts)
 				continue
-			} else if httpRes.StatusCode == 401 && res.Get("error.messages.0.description").String() == "Invalid session." {
-				log.Printf("[DEBUG] Got: '%s'", res.Get("error.messages.0.description").String())
-				log.Printf("[DEBUG] Invalid session detected. Reauthenticating")
+			} else if httpRes.StatusCode == 401 {
+				// There are bugs in FMC, where the sessions are invalidated out of the blue
+				// In case such a situation is detected, new authentication is forced
+				log.Printf("[DEBUG] Invalid session detected. Forcing reauthentication")
+				// Clear AuthToken (which is invalid anyways). This also ensures that Authenticate does full authentication
 				client.AuthToken = ""
+				// Force reauthentication, client.Authenticate() takes care of mutexes, hence not calling Login() directly
 				err := client.Authenticate()
 				if err != nil {
-					return res, fmt.Errorf("HTTP Request failed: StatusCode 401: Reauthentication failed: %s", err)
+					log.Printf("[DEBUG] HTTP Request failed: StatusCode 401: Forced reauthentication failed: %s", err)
+					return res, fmt.Errorf("HTTP Request failed: StatusCode 401: Forced reauthentication failed: %s", err)
 				}
+				req.HttpReq.Header.Set("X-auth-access-token", client.AuthToken)
+				continue
 			} else {
 				log.Printf("[ERROR] HTTP Request failed: StatusCode %v", httpRes.StatusCode)
 				log.Printf("[DEBUG] Exit from Do method")

--- a/client.go
+++ b/client.go
@@ -238,8 +238,8 @@ func (client *Client) Do(req Req) (Res, error) {
 				// Force reauthentication, client.Authenticate() takes care of mutexes, hence not calling Login() directly
 				err := client.Authenticate()
 				if err != nil {
-					log.Printf("[DEBUG] HTTP Request failed: StatusCode 401: Forced reauthentication failed: %s", err)
-					return res, fmt.Errorf("HTTP Request failed: StatusCode 401: Forced reauthentication failed: %s", err)
+					log.Printf("[DEBUG] HTTP Request failed: StatusCode 401: Forced reauthentication failed: %s", err.Error())
+					return res, fmt.Errorf("HTTP Request failed: StatusCode 401: Forced reauthentication failed: %s", err.Error())
 				}
 				req.HttpReq.Header.Set("X-auth-access-token", client.AuthToken)
 				continue


### PR DESCRIPTION
There are bugs in FMC, where long lived sessions (1 hour or longer) may be terminated unexpectedly.
This is a workaround for that situation, where authentication is forced once such a situation is detected