### PR TITLE
support for HTTP400 - try again

### DIFF
--- a/client.go
+++ b/client.go
@@ -273,6 +273,12 @@ func (client *Client) Do(req Req) (Res, error) {
 				}
 				req.HttpReq.Header.Set("X-auth-access-token", client.AuthToken)
 				continue
+			} else if desc := res.Get("error.messages.0.description"); desc.Exists() {
+				// FMC may return HTTP response code 400 with a message "please try again"
+				if strings.Contains(strings.ToLower(desc.String()), "please try again") {
+					log.Printf("[ERROR] HTTP Request failed with 'please try again'. Retrying.")
+					continue
+				}
 			} else {
 				log.Printf("[ERROR] HTTP Request failed: StatusCode %v", httpRes.StatusCode)
 				log.Printf("[DEBUG] Exit from Do method")


### PR DESCRIPTION
FMC may return HTTP code 400 with the following error:
"{"error":{"category":"FRAMEWORK","messages":[{"description":"Search Service n.a. Please try again."}],"severity":"ERROR"}}"

By default, 400 errors are not retired, as this is supposed to be client error. This PR adds exception, so request resulting with the above error is retried.

