### PR TITLE
Bug in HTTP StatusCode error handling logic

### DIFF
--- a/client.go
+++ b/client.go
@@ -279,11 +279,11 @@ func (client *Client) Do(req Req) (Res, error) {
 					log.Printf("[ERROR] HTTP Request failed with 'please try again'. Retrying.")
 					continue
 				}
-			} else {
-				log.Printf("[ERROR] HTTP Request failed: StatusCode %v", httpRes.StatusCode)
-				log.Printf("[DEBUG] Exit from Do method")
-				return res, fmt.Errorf("HTTP Request failed: StatusCode %v", httpRes.StatusCode)
 			}
+			// In case any previous conditions don't `continue`, return error
+			log.Printf("[ERROR] HTTP Request failed: StatusCode %v", httpRes.StatusCode)
+			log.Printf("[DEBUG] Exit from Do method")
+			return res, fmt.Errorf("HTTP Request failed: StatusCode %v", httpRes.StatusCode)
 		}
 	}
 


### PR DESCRIPTION
The following `else if desc := res.Get("error.messages.0.description"); desc.Exists() {` introduced a bug into the code.
In case the FMC would respond with any error message, the main loop would continue as the final `else` is always skipped.
This would make requests resulting in error (regardless what it is) repeat until max backoff count is reached.

Proposal is to put the final statements, that return error outside of `else` block, which will make this block always executed, unless any condition `continue` the loop.