### PR TITLE
Fix: Implement retry logic for FMC 'retry the operation' message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.1 (Unreleased)
 
 - Fix: cdFMC client fails if user sets `DomainName` modifier, even it was for `Global` domain
+- Fix: FMC may return an error indicating, "Retry the operation after some time." In such cases, the client will adhere to this guidance rather than failing immediately.
 
 ## 0.2.0
 

--- a/client.go
+++ b/client.go
@@ -328,9 +328,10 @@ func (client *Client) Do(req Req) (Res, error) {
 				req.HttpReq.Header.Set("X-auth-access-token", client.AuthToken)
 				continue
 			} else if desc := res.Get("error.messages.0.description"); desc.Exists() {
-				// FMC may return HTTP response code 400 with a message "please try again"
-				if strings.Contains(strings.ToLower(desc.String()), "please try again") {
-					log.Printf("[ERROR] HTTP Request failed with 'please try again'. Retrying.")
+				// FMC may return HTTP response code 400 with advice to retry the operation
+				if strings.Contains(strings.ToLower(desc.String()), "please try again") ||
+					strings.Contains(strings.ToLower(desc.String()), "retry the operation after sometime") {
+					log.Printf("[ERROR] HTTP Request failed with advice to try again. Retrying.")
 					continue
 				}
 			}


### PR DESCRIPTION
Fix: FMC may return an error indicating, "Retry the operation after some time." In such cases, the client will adhere to this guidance rather than failing immediately.