### PR TITLE
An attempt to fix races in authentication flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.2 (Unreleased)
 
+- BREAKING CHANGE: `login()` and `refresh()` functions are no logner exported
+- BREAKING CHANGE: `Authenticate()` is now defined as `Authenticate(failedAuthToken string)`
+- Fix: Possible race-conditions and miss-handling of the FMC authentication tokens
 - Enh: Introduced ReqID to correlate events in the logs
 - Enh: FMC 7.4.1, 7.6.0 and later releases have rate-limit increased to 300 req/min
 

--- a/client.go
+++ b/client.go
@@ -603,9 +603,11 @@ func (client *Client) AuthToken() string {
 }
 
 // Authenticate assures the token is there and valid.
-// It will try to login/refresh the token based on the current state and information from FMC on failures.
-// currentAuthToken is the token used in the request, that was rejected by FMC. This helps to
-// determine, if failed token needs refreshing or has already been refreshed by other thread.
+// It will try to login/refresh the token based on the current state and information
+// from FMC on failures (no proactive reauthentications).
+// currentAuthToken is the token used in the request. This helps to
+// determine, if authToken needs refreshing or has already been refreshed by other thread.
+// currentAuthToken can be an empty string.
 func (client *Client) Authenticate(currentAuthToken string) error {
 	// cdFMC uses fixed token to authenticate
 	if client.IsCDFMC {

--- a/client.go
+++ b/client.go
@@ -317,7 +317,6 @@ func (client *Client) Do(req Req) (Res, error) {
 
 		bodyBytes, err := io.ReadAll(httpRes.Body)
 		httpRes.Body.Close()
-
 		if err != nil {
 			if ok := client.Backoff(attempts); !ok {
 				log.Printf("[ERROR] [ReqID: %s] Cannot decode response body: %+v", req.RequestID, err)
@@ -522,7 +521,6 @@ func (client *Client) login() error {
 		}
 		bodyBytes, _ := io.ReadAll(httpRes.Body)
 		httpRes.Body.Close()
-
 		if httpRes.StatusCode != 204 {
 			log.Printf("[ERROR] Authentication failed: StatusCode %v", httpRes.StatusCode)
 			return fmt.Errorf("authentication failed, status code: %v", httpRes.StatusCode)
@@ -541,7 +539,6 @@ func (client *Client) login() error {
 		client.refreshToken = httpRes.Header.Get("X-auth-refresh-token")
 		client.LastRefresh = time.Now()
 		client.RefreshCount = 0
-
 		client.DomainUUID = httpRes.Header.Get("DOMAIN_UUID")
 		client.Domains = make(map[string]string)
 		gjson.Parse(httpRes.Header.Get("DOMAINS")).ForEach(func(k, v gjson.Result) bool {
@@ -562,10 +559,8 @@ func (client *Client) login() error {
 func (client *Client) refresh() error {
 	for attempts := 0; ; attempts++ {
 		req, _ := client.NewReq("POST", "/api/fmc_platform/v1/auth/refreshtoken", strings.NewReader(""), NoLogPayload)
-
 		req.HttpReq.Header.Add("X-auth-access-token", client.authToken)
 		req.HttpReq.Header.Add("X-auth-refresh-token", client.refreshToken)
-
 		req.HttpReq.Header.Add("User-Agent", client.UserAgent)
 		client.RateLimiterBucket.Wait(1)
 		httpRes, err := client.HttpClient.Do(req.HttpReq)
@@ -574,7 +569,6 @@ func (client *Client) refresh() error {
 		}
 		bodyBytes, _ := io.ReadAll(httpRes.Body)
 		httpRes.Body.Close()
-
 		if httpRes.StatusCode != 204 {
 			log.Printf("[ERROR] Authentication token refresh failed: StatusCode %v", httpRes.StatusCode)
 			return fmt.Errorf("authentication token refresh failed, status code: %v", httpRes.StatusCode)
@@ -593,7 +587,6 @@ func (client *Client) refresh() error {
 		client.refreshToken = httpRes.Header.Get("X-auth-refresh-token")
 		client.LastRefresh = time.Now()
 		client.RefreshCount = client.RefreshCount + 1
-
 		client.DomainUUID = httpRes.Header.Get("DOMAIN_UUID")
 
 		log.Printf("[DEBUG] Authentication token refresh successful")
@@ -638,10 +631,7 @@ func (client *Client) Authenticate(failedAuthToken string) error {
 	if authToken == "" {
 		// No token, do a full login
 		err = client.login()
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	}
 
 	// First check if we can refresh the token

--- a/client.go
+++ b/client.go
@@ -604,9 +604,9 @@ func (client *Client) AuthToken() string {
 
 // Authenticate assures the token is there and valid.
 // It will try to login/refresh the token based on the current state and information from FMC on failures.
-// invalidAuthToken is the token used in the request, that was rejected by FMC. This helps to
+// currentAuthToken is the token used in the request, that was rejected by FMC. This helps to
 // determine, if failed token needs refreshing or has already been refreshed by other thread.
-func (client *Client) Authenticate(invalidAuthToken string) error {
+func (client *Client) Authenticate(currentAuthToken string) error {
 	// cdFMC uses fixed token to authenticate
 	if client.IsCDFMC {
 		return nil
@@ -615,12 +615,12 @@ func (client *Client) Authenticate(invalidAuthToken string) error {
 	client.authenticationMutex.Lock()
 	defer client.authenticationMutex.Unlock()
 
-	if client.authToken != "" && invalidAuthToken == "" {
+	if client.authToken != "" && currentAuthToken == "" {
 		// authToken is present, no error reported, do nothing
 		return nil
 	}
 
-	if invalidAuthToken != "" && invalidAuthToken != client.authToken {
+	if currentAuthToken != "" && currentAuthToken != client.authToken {
 		// authToken has changed since the last request
 		// we assume some other thread has already refreshed it, do nothing
 		return nil

--- a/client_cdfmc_test.go
+++ b/client_cdfmc_test.go
@@ -109,7 +109,7 @@ func TestClientCDFMCGetRetry(t *testing.T) {
 
 	// Create client
 	client, _ := NewClientCDFMC(testURL, "pwd", CustomHttpClient(httpClient), MaxRetries(3), BackoffMinDelay(0))
-	client.AuthToken = "ABC"
+	client.authToken = "ABC"
 
 	// Request should fail
 	gock.New(testURL).Get("/url_400").Reply(400)

--- a/client_test.go
+++ b/client_test.go
@@ -91,11 +91,11 @@ func TestClientLogin(t *testing.T) {
 
 	// Successful login
 	gock.New(testURL).Post("/api/fmc_platform/v1/auth/generatetoken").Reply(204)
-	assert.NoError(t, client.Login())
+	assert.NoError(t, client.login())
 
 	// Unsuccessful token retrieval
 	gock.New(testURL).Post("/api/fmc_platform/v1/auth/generatetoken").Reply(401)
-	assert.Error(t, client.Login())
+	assert.Error(t, client.login())
 }
 
 // TestClientGetFMCVersion tests the Client::GetFMCVersion method.

--- a/client_test.go
+++ b/client_test.go
@@ -34,7 +34,7 @@ func testClient() Client {
 
 func authenticatedTestClient() Client {
 	client := testClient()
-	client.AuthToken = "ABC"
+	client.authToken = "ABC"
 	client.LastRefresh = time.Now()
 	client.RefreshCount = 0
 	client.DomainUUID = "ABC123"
@@ -151,7 +151,7 @@ func TestClientGetRetry(t *testing.T) {
 
 	// Create client
 	client, _ := NewClient(testURL, "usr", "pwd", CustomHttpClient(httpClient), MaxRetries(3), BackoffMinDelay(0))
-	client.AuthToken = "ABC"
+	client.authToken = "ABC"
 	client.LastRefresh = time.Now()
 
 	// Request should fail


### PR DESCRIPTION
This PR attempts to fix improper handling of the authentication token, where it was read/cleared without proper protection, which could impact other go-fmc threads and cascade errors, triggering multiple re-authentications.

It does also change the logic of pro-active and re-active token refresh to purely re-active approach (token is refreshed when considered invalid by FMC).

---
It would be more idiomatic in Go to do this with channels, but that would be a complete refactor of the code, and I didn’t want to leave you guys with something much harder to maintain and much more difficult as that'd be an approach completely different to what we're all used to from "traditional" languages.

CC @rchrabas 