### PR TITLE
Enh: Adjust API rate-limit to detected FMC version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2 (Unreleased)
+
+- Enh: FMC 7.4.1, 7.6.0 and later releases have rate-limit increased to 300 req/min
+
 ## 0.2.1
 
 - Fix: cdFMC client fails if user sets `DomainName` modifier, even it was for `Global` domain

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-version"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
@@ -71,8 +72,10 @@ type Client struct {
 	DomainUUID string
 	// Map of domain names to domain UUIDs.
 	Domains map[string]string
-	// FMC Version
+	// FMC Version string as returned by FMC - ex. 7.7.0 (build 91)
 	FMCVersion string
+	// FMC Version parsed to go-version library - ex. 7.7.0
+	FMCVersionParsed *version.Version
 	// Is this cdFMC connection
 	IsCDFMC bool
 
@@ -120,7 +123,23 @@ func NewClient(url, usr, pwd string, mods ...func(*Client)) (Client, error) {
 
 	err := client.GetFMCVersion()
 	if err != nil {
+		log.Printf("[ERROR] Failed to retrieve FMC version: %s", err.Error())
 		return client, err
+	}
+
+	// Compile FMC version to go-version
+	client.FMCVersionParsed, err = version.NewVersion(strings.Split(client.FMCVersion, " ")[0])
+	if err != nil {
+		log.Printf("[ERROR] Failed to parse FMC version (%s): %s", client.FMCVersion, err.Error())
+		return client, fmt.Errorf("failed to parse FMC version (%s): %s", client.FMCVersion, err.Error())
+	}
+
+	log.Printf("[INFO] FMC Version: %s, FMC Version Parsed: %s", client.FMCVersion, client.FMCVersionParsed.String())
+
+	// FMC 7.4.1, 6.6.0 and later have increased rate limits
+	if client.FMCVersionParsed.GreaterThanOrEqual(version.Must(version.NewVersion("7.4.1"))) {
+		log.Printf("[DEBUG] Increasing rate limit to 5 req/s (300 req/min)")
+		client.RateLimiterBucket = ratelimit.NewBucketWithRate(5, 1) // 5 req/s = 300 req/min
 	}
 
 	return client, nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/netascode/go-fmc
 go 1.23.6
 
 require (
+	github.com/hashicorp/go-version v1.7.0
 	github.com/juju/ratelimit v1.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
 github.com/juju/ratelimit v1.0.2/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=


### PR DESCRIPTION
Enh: FMC 7.4.1, 7.6.0 and later releases have rate-limit increased to 300 req/min